### PR TITLE
Add .prettierrc for yml files

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "tabWidth": 2,
+  "overrides": [
+    {
+      "files": "*.yml",
+      "options": {
+        "tabWidth": 2
+      }
+    }
+  ]
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,15 @@
 {
   "overrides": [
     {
-      "files": "*.yml",
+      "files": ["*.yml", "*.yaml"],
       "options": {
         "tabWidth": 2
+      }
+    },
+    {
+      "files": "*.json",
+      "options": {
+        "tabWidth": 4
       }
     }
   ]

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,4 @@
 {
-  "tabWidth": 2,
   "overrides": [
     {
       "files": "*.yml",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+    // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+    // List of extensions which should be recommended for users of this workspace.
+    "recommendations": ["esbenp.prettier-vscode"],
+    // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+    "unwantedRecommendations": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,4 +5,14 @@
     "python.linting.flake8Path": "flake8",
     "editor.formatOnSave": true,
     "python.formatting.provider": "black",
+    "prettier.tabWidth": 4,
+    "[yaml]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[json]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[jsonc]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    }
 }

--- a/examples/auth.yml
+++ b/examples/auth.yml
@@ -1,22 +1,22 @@
 AUTH:
-    - keycloak:
-          ENABLED: true
-          AUTH_MODULE: "pyispyb.app.extensions.auth.KeycloakDBGroupsAuthentication"
-          AUTH_CLASS: "KeycloakDBGroupsAuthentication"
-          CONFIG:
-              KEYCLOAK_SERVER_URL: "your_server"
-              KEYCLOAK_CLIENT_ID: "your_client"
-              KEYCLOAK_REALM_NAME: "your_realm"
-              KEYCLOAK_CLIENT_SECRET_KEY: "your_secret"
-    - ldap:
-          ENABLED: true
-          AUTH_MODULE: "pyispyb.app.extensions.auth.LdapAuthentication"
-          AUTH_CLASS: "LdapAuthentication"
-          CONFIG:
-              LDAP_URI: "ldap://your_ldap"
-              LDAP_BASE_INTERNAL: "ou=People,dc=esrf,dc=fr"
-              LDAP_BASE_EXTERNAL: "ou=Pxwebgroups,dc=esrf,dc=fr"
-    - dummy: # /!\/!\/!\ ONLY USE FOR TESTS /!\/!\/!\
-          ENABLED: false
-          AUTH_MODULE: "pyispyb.app.extensions.auth.DummyAuthentication"
-          AUTH_CLASS: "DummyAuthentication"
+  - keycloak:
+      ENABLED: true
+      AUTH_MODULE: "pyispyb.app.extensions.auth.KeycloakDBGroupsAuthentication"
+      AUTH_CLASS: "KeycloakDBGroupsAuthentication"
+      CONFIG:
+        KEYCLOAK_SERVER_URL: "your_server"
+        KEYCLOAK_CLIENT_ID: "your_client"
+        KEYCLOAK_REALM_NAME: "your_realm"
+        KEYCLOAK_CLIENT_SECRET_KEY: "your_secret"
+  - ldap:
+      ENABLED: true
+      AUTH_MODULE: "pyispyb.app.extensions.auth.LdapAuthentication"
+      AUTH_CLASS: "LdapAuthentication"
+      CONFIG:
+        LDAP_URI: "ldap://your_ldap"
+        LDAP_BASE_INTERNAL: "ou=People,dc=esrf,dc=fr"
+        LDAP_BASE_EXTERNAL: "ou=Pxwebgroups,dc=esrf,dc=fr"
+  - dummy: # /!\/!\/!\ ONLY USE FOR TESTS /!\/!\/!\
+      ENABLED: false
+      AUTH_MODULE: "pyispyb.app.extensions.auth.DummyAuthentication"
+      AUTH_CLASS: "DummyAuthentication"


### PR DESCRIPTION
This makes yaml indentation consistent across vscode instances