### PR TITLE
Hotfix ci tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ python_ldap==3.4.0
 sqlparse
 
 mysql-connector
-mysql-connector-python
+mysql-connector-python==8.0.29
 
 mkdocs
 mkdocs-material


### PR DESCRIPTION
https://dev.mysql.com/doc/relnotes/connector-python/en/news-8-0-30.html

Pertinent info seems to be:

> Added or renamed collations as per MySQL Server 8.0.30. This includes adding support for the new language-specific utf8mb4 collations and renaming all existing utf8_* collations to utf8mb3_*. This also makes utf8 an alias to utf8mb4. Support for MySQL 5.7 collations were preserved for connections to a MySQL 5.7 server.