### PR TITLE
Add onetime tokens

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -1,0 +1,11 @@
+# Developer Notes
+
+## Authentication
+
+Authentication is generally handled via [JSON Web Tokens](https://jwt.io/) (JWT) which should be passed in the `Authorization` header with a value `Bearer {token}`. Most the of the py-ISPyB resources require a token to be present.
+
+In certain situations it is not possible to use a JWT. For example when downloading a file it is not possible to pass an Authorization header. For these situations py-ISPyB provides a one time token system. A one time token can be generated for a particular url and this token can then be used as a query parameter to access the specified url a single time. Unused tokens are expired on a short time scale. A signed url can be generated using the `/user/sign` resource, and used as so:
+
+```
+GET /datacollections/attachments/2?onetime={token}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
   - Simulator: simulator.md
   - User Portal Sync: upsync.md
   - Developers:
+      - Notes: developers.md
       - ⧉ Test coverage: https://app.codecov.io/gh/ispyb/py-ispyb/
 
 theme:

--- a/pyispyb/app/extensions/auth/bearer.py
+++ b/pyispyb/app/extensions/auth/bearer.py
@@ -27,14 +27,8 @@ async def JWTBearer(
     onetime: str = Depends(onetime),
     credentials: HTTPAuthorizationCredentials = Depends(security),
 ):
-    # One time token authentication
-    expire_onetime_tokens()
-    if onetime:
-        person_dict = validate_onetime_token(onetime, request.url.components.path)
-        set_token_data(person_dict)
-
     # JWT authentication
-    elif credentials:
+    if credentials:
         if not credentials.scheme == "Bearer":
             raise HTTPException(
                 status_code=401, detail="Invalid authentication scheme."
@@ -48,6 +42,11 @@ async def JWTBearer(
         set_token_data(decoded)
 
         return credentials.credentials
+
+    # One time token authentication
+    elif onetime:
+        person_dict = validate_onetime_token(onetime, request.url.components.path)
+        set_token_data(person_dict)
     else:
         raise HTTPException(status_code=401, detail="No token provided.")
 

--- a/pyispyb/app/extensions/auth/bearer.py
+++ b/pyispyb/app/extensions/auth/bearer.py
@@ -4,7 +4,7 @@ import jwt
 
 from ...globals import g
 from .token import decode_token, set_token_data
-from .onetime import expire_onetime_tokens, onetime, validate_onetime_token
+from .onetime import onetime, validate_onetime_token
 
 # auto_error=False to correct 403 -> 401
 # https://github.com/tiangolo/fastapi/issues/2026

--- a/pyispyb/app/extensions/auth/onetime.py
+++ b/pyispyb/app/extensions/auth/onetime.py
@@ -1,0 +1,111 @@
+import logging
+import secrets
+from typing import Optional
+from urllib.parse import urlparse
+
+from fastapi import Query, HTTPException
+from ispyb import models
+from sqlalchemy import text
+
+from ....config import settings
+from ...extensions.database.definitions import get_current_person
+from ...extensions.database.middleware import db
+
+logger = logging.getLogger(__name__)
+
+
+def onetime(
+    onetime: Optional[str] = Query(
+        None,
+        description="One time token",
+        include_in_schema=False,
+        regex=r"^([\w\-_])+$",
+    )
+) -> str:
+    return onetime
+
+
+def generate_onetime_token(validity: str, personId: int) -> str:
+    """Generate a one time token
+
+    Kwargs:
+        validity (str): The path this token is valid for
+        login (str): The associated person login
+
+    Returns:
+        token(str): The generated token
+    """
+    parsed = urlparse(validity)
+    path = parsed.path
+    path = path.replace(settings.api_root, "")
+
+    token = secrets.token_urlsafe(96)
+    once_token = models.SWOnceToken(
+        personId=personId,
+        validity=path,
+        token=token,
+    )
+    db.session.add(once_token)
+    return token
+
+
+def validate_onetime_token(token: str, validity: str) -> models.Person:
+    """Validate a one time token
+
+    Kwargs:
+        token (str): The token to validate
+        validity (str): The current path
+
+    Returns:
+        person (models.Person): The validated person
+    """
+    if not hasattr(models, "SWOnceToken"):
+        raise RuntimeError("Missing table `SWOnceToken`")
+
+    once_token: models.SWOnceToken = (
+        db.session.query(models.SWOnceToken)
+        .filter(models.SWOnceToken.token == token)
+        .first()
+    )
+
+    if not once_token:
+        logger.warning("Unknown one time token")
+        raise HTTPException(status_code=401, detail="Invalid one time token.")
+
+    if validity != settings.api_root + once_token.validity:
+        logger.warning(
+            f"One time token validtiy `{once_token.validity}` and path `{validity}` do not match"
+        )
+        raise HTTPException(status_code=401, detail="Invalid one time token.")
+
+    login = (
+        db.session.query(models.Person.login)
+        .filter(models.Person.personId == once_token.personId)
+        .first()
+    )
+    person = get_current_person(login[0])
+
+    db.session.delete(once_token)
+    db.session.commit()
+
+    return {
+        "login": person.login,
+        "personId": person.personId,
+        "permissions": person._metadata["permissions"],
+    }
+
+
+def expire_onetime_tokens(expiry: int = 5) -> None:
+    """Expire one time tokens
+
+    Delete all tokens generated more than 10 seconds ago that are unused
+
+    Kwargs:
+        expiry (int): Seconds tokens are valid for
+    """
+    if not isinstance(expiry, int):
+        raise RuntimeError(f"Expiry {expiry} is a none integer value")
+
+    db.session.query(models.SWOnceToken).filter(
+        models.SWOnceToken.recordTimeStamp < text(f"NOW() - INTERVAL {expiry} SECOND")
+    ).delete(synchronize_session="fetch")

--- a/pyispyb/app/extensions/auth/onetime.py
+++ b/pyispyb/app/extensions/auth/onetime.py
@@ -74,7 +74,7 @@ def validate_onetime_token(token: str, validity: str) -> models.Person:
 
     if validity != settings.api_root + once_token.validity:
         logger.warning(
-            f"One time token validtiy `{once_token.validity}` and path `{validity}` do not match"
+            f"One time token validity `{settings.api_root+once_token.validity}` and path `{validity}` do not match"
         )
         raise HTTPException(status_code=401, detail="Invalid one time token.")
 

--- a/pyispyb/app/main.py
+++ b/pyispyb/app/main.py
@@ -1,19 +1,21 @@
-from typing import Any
 import logging
 from logging.config import dictConfig
+from typing import Any
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
 
-from pyispyb.app.extensions.database.utils import enable_debug_logging
-from pyispyb.app.extensions.database.middleware import get_session
-from pyispyb.app.extensions.options.base import setup_options
-from pyispyb.app.globals import GlobalsMiddleware
+from ..app.extensions.auth.onetime import expire_ontime_tokens_periodically
+from ..app.extensions.database.utils import enable_debug_logging
+from ..app.extensions.database.middleware import get_session
+from ..app.extensions.options.base import setup_options
+from ..app.globals import GlobalsMiddleware
 
 from ..config import settings, LogConfig
-from pyispyb.app import routes as base_routes
-from pyispyb.core import routes as core_routes
-from pyispyb.app.extensions.auth import auth_provider
+from ..app import routes as base_routes
+from ..core import routes as core_routes
+from ..app.extensions.auth import auth_provider
 
 dictConfig(LogConfig().dict())
 logger = logging.getLogger("ispyb")
@@ -30,6 +32,11 @@ async def get_session_as_middleware(request, call_next):
 
 
 setup_options(app)
+
+
+@app.on_event("startup")
+async def expire_onetime_tokens() -> None:
+    await expire_ontime_tokens_periodically()
 
 
 def enable_cors() -> None:

--- a/tests/core/api/test_authentication.py
+++ b/tests/core/api/test_authentication.py
@@ -58,7 +58,7 @@ def test_onetime(client: TestClient):
 
     headers = {"Authorization": f"Bearer {res.json()['token']}"}
     res2 = client.post(
-        f"{settings.api_root}/user/sign", headers=headers, json={"validity": "/events/"}
+        f"{settings.api_root}/user/sign", headers=headers, json={"validity": "/events"}
     )
     assert res2.status_code == 200
 

--- a/tests/core/api/test_authentication.py
+++ b/tests/core/api/test_authentication.py
@@ -64,9 +64,3 @@ def test_onetime(client: TestClient):
 
     res = client.get(f"{settings.api_root}/events?onetime={res2.json()['token']}")
     assert res.status_code == 200
-
-
-def test_onetime_expired(client: TestClient):
-    res = client.get(f"{settings.api_root}/events?onetime=one")
-    assert res.status_code == 401
-    assert "invalid" in res.json()["detail"].lower()

--- a/tests/core/api/test_authentication.py
+++ b/tests/core/api/test_authentication.py
@@ -30,8 +30,43 @@ def test_token_expired(client: TestClient, short_session: float):
     assert "expired" in res2.json()["detail"].lower()
 
 
+def test_no_token(client: TestClient):
+    res = client.get(f"{settings.api_root}/events")
+    assert res.status_code == 401
+    assert "no token" in res.json()["detail"].lower()
+
+
 def test_token_invalid(client: TestClient):
     headers = {"Authorization": "Bearer asda.asda.asda"}
     res = client.get(f"{settings.api_root}/events", headers=headers)
+    assert res.status_code == 401
+    assert "invalid" in res.json()["detail"].lower()
+
+
+def test_onetime_invalid(client: TestClient):
+    res = client.get(f"{settings.api_root}/events?onetime=one")
+    assert res.status_code == 401
+    assert "invalid" in res.json()["detail"].lower()
+
+
+def test_onetime(client: TestClient):
+    res = client.post(
+        f"{settings.api_root}/auth/login",
+        json={"login": "abcd", "password": "abcd", "plugin": "dummy"},
+    )
+    assert res.status_code == 201
+
+    headers = {"Authorization": f"Bearer {res.json()['token']}"}
+    res2 = client.post(
+        f"{settings.api_root}/user/sign", headers=headers, json={"validity": "/events/"}
+    )
+    assert res2.status_code == 200
+
+    res = client.get(f"{settings.api_root}/events?onetime={res2.json()['token']}")
+    assert res.status_code == 200
+
+
+def test_onetime_expired(client: TestClient):
+    res = client.get(f"{settings.api_root}/events?onetime=one")
     assert res.status_code == 401
     assert "invalid" in res.json()["detail"].lower()


### PR DESCRIPTION
Adds onetime tokens to allow the client to download files from the api. Urls are signed and a unique token generated which is stored in the db. This can be used a single time to download the signed url, and otherwise expire on a short timescale (10s)

to be merged after https://github.com/ispyb/py-ispyb/pull/203