### PR TITLE
fix: Pin mysql-connector-python and remove unneccessary packages (#218)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ uvicorn
 SQLAlchemy
 
 pyjwt
-mysqlclient
 pdfkit
 python-barcode
 qrcode
@@ -21,7 +20,6 @@ python_ldap==3.4.0
 
 sqlparse
 
-mysql-connector
 mysql-connector-python==8.0.29
 
 mkdocs

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,8 +43,7 @@ install_requires =
     ; keycloak-client
     ; python_ldap == 3.4.0
     sqlparse
-    mysql-connector
-    mysql-connector-python
+    mysql-connector-python == 8.0.29
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
* Pin version 8.0.29 of mysql-connector-python and remove mysql-connector in setup.cfg
* Remove mysqlclient and mysql-connector from requirements.txt

Partly as outlined in issue #218 .