### PR TITLE
Adds EM endpoints

### DIFF
--- a/pyispyb/core/modules/em.py
+++ b/pyispyb/core/modules/em.py
@@ -62,20 +62,23 @@ def get_fft_thumbnail_path(movieId: int) -> str:
 def get_movies(skip: int, limit: int, dataCollectionId: int) -> Paged[schema.FullMovie]:
     query = (
         db.session.query(models.MotionCorrection, models.CTF, models.Movie)
+        .select_from(models.Movie)
         .join(
             models.MotionCorrection,
             models.MotionCorrection.movieId == models.Movie.movieId,
         )
-        .join(models.CTF)
+        .join(
+            models.CTF,
+            models.CTF.motionCorrectionId == models.MotionCorrection.motionCorrectionId,
+        )
         .join(
             models.DataCollection,
-            models.DataCollection.dataCollectionId
-            == models.MotionCorrection.dataCollectionId,
+            models.DataCollection.dataCollectionId == models.Movie.dataCollectionId,
         )
         .join(models.DataCollectionGroup)
         .join(models.BLSession)
         .join(models.Proposal)
-        .order_by(models.MotionCorrection.imageNumber)
+        .order_by(models.MotionCorrection.motionCorrectionId)
         .group_by(models.Movie.movieId)
     )
 
@@ -86,5 +89,7 @@ def get_movies(skip: int, limit: int, dataCollectionId: int) -> Paged[schema.Ful
     query = with_authorization(query, joinBLSession=False)
     query = page(query, skip=skip, limit=limit)
     results = query.all()
+
+    print(results)
 
     return Paged(total=total, results=results, skip=skip, limit=limit)

--- a/pyispyb/core/modules/em.py
+++ b/pyispyb/core/modules/em.py
@@ -1,0 +1,90 @@
+import logging
+import os
+
+from ispyb import models
+
+from ...app.extensions.database.definitions import (
+    with_authorization,
+)
+from ...app.extensions.database.utils import Paged, page
+from ...app.extensions.database.middleware import db
+from ..schemas import em as schema
+
+logger = logging.getLogger(__name__)
+
+
+def get_micrograph_snapshot_path(movieId: int) -> str:
+    query = (
+        db.session.query(models.MotionCorrection.micrographSnapshotFullPath)
+        .filter(models.MotionCorrection.movieId == movieId)
+        .join(models.DataCollection)
+        .join(models.DataCollectionGroup)
+        .join(models.BLSession)
+        .join(models.Proposal)
+    )
+
+    query = with_authorization(query, joinBLSession=False)
+    path = query.scalar()
+
+    if path:
+        if os.path.exists(path):
+            return path
+        logger.warning(
+            f"Micrograph image {path} for movie {movieId} does not exist on disk"
+        )
+    return None
+
+
+def get_fft_thumbnail_path(movieId: int) -> str:
+    query = (
+        db.session.query(models.CTF.fftTheoreticalFullPath)
+        .select_from(models.MotionCorrection)
+        .filter(models.MotionCorrection.movieId == movieId)
+        .join(models.CTF)
+        .join(models.DataCollection)
+        .join(models.DataCollectionGroup)
+        .join(models.BLSession)
+        .join(models.Proposal)
+    )
+
+    query = with_authorization(query, joinBLSession=False)
+    path = query.scalar()
+
+    if path:
+        if os.path.exists(path):
+            return path
+        logger.warning(
+            f"Micrograph image {path} for movie {movieId} does not exist on disk"
+        )
+    return None
+
+
+def get_movies(skip: int, limit: int, dataCollectionId: int) -> Paged[schema.FullMovie]:
+    query = (
+        db.session.query(models.MotionCorrection, models.CTF, models.Movie)
+        .join(
+            models.MotionCorrection,
+            models.MotionCorrection.movieId == models.Movie.movieId,
+        )
+        .join(models.CTF)
+        .join(
+            models.DataCollection,
+            models.DataCollection.dataCollectionId
+            == models.MotionCorrection.dataCollectionId,
+        )
+        .join(models.DataCollectionGroup)
+        .join(models.BLSession)
+        .join(models.Proposal)
+        .order_by(models.MotionCorrection.imageNumber)
+        .group_by(models.Movie.movieId)
+    )
+
+    if dataCollectionId:
+        query = query.filter(models.Movie.dataCollectionId == dataCollectionId)
+
+    total = query.count()
+    query = with_authorization(query, joinBLSession=False)
+    query = page(query, skip=skip, limit=limit)
+    results = query.all()
+
+    return Paged(total=total, results=results, skip=skip, limit=limit)

--- a/pyispyb/core/routes/em.py
+++ b/pyispyb/core/routes/em.py
@@ -1,0 +1,48 @@
+import logging
+
+from fastapi import Depends, HTTPException
+from fastapi.responses import FileResponse
+
+from ...dependencies import pagination
+from ...app.extensions.database.utils import Paged
+from ... import filters
+from ...app.base import AuthenticatedAPIRouter
+
+from ..modules import em as crud
+from ..schemas import em as schema
+from ..schemas.utils import paginated
+
+
+logger = logging.getLogger(__name__)
+router = AuthenticatedAPIRouter(prefix="/em", tags=["EM"])
+
+
+@router.get("/snapshot/micrograph", response_class=FileResponse)
+def get_micrograph_snapshot(movieId: int = Depends(filters.movieId)) -> str:
+    """Get micrograph snapshot"""
+    path = crud.get_micrograph_snapshot_path(movieId=movieId)
+
+    if not path:
+        raise HTTPException(status_code=404, detail="Image not found")
+
+    return path
+
+
+@router.get("/thumbnail/fft", response_class=FileResponse)
+def get_fft_thumbnail(movieId: int = Depends(filters.movieId)) -> str:
+    """Get FFT thumbnail"""
+    path = crud.get_fft_thumbnail_path(movieId=movieId)
+
+    if not path:
+        raise HTTPException(status_code=404, detail="Image not found")
+
+    return path
+
+
+@router.get("/movies", response_model=paginated(schema.FullMovie))
+def get_movies(
+    dataCollectionId: int = Depends(filters.dataCollectionId),
+    page: dict[str, int] = Depends(pagination),
+) -> Paged[schema.FullMovie]:
+    """Get movies for a data collection"""
+    return crud.get_movies(dataCollectionId=dataCollectionId, **page)

--- a/pyispyb/core/schemas/em.py
+++ b/pyispyb/core/schemas/em.py
@@ -1,0 +1,121 @@
+from typing import Optional
+from pydantic import BaseModel, Field
+from datetime import datetime
+
+
+class Tomogram(BaseModel):
+    tomogramId: int
+    dataCollectionId: int
+    autoProcProgramId: Optional[int]
+    volumeFile: Optional[str] = Field(..., max_length=255)
+    stackFile: Optional[str] = Field(..., max_length=255)
+    sizeX: Optional[int]
+    sizeY: Optional[int]
+    sizeZ: Optional[int]
+    pixelSpacing: Optional[float]
+    residualErrorMean: Optional[float]
+    residualErrorSD: Optional[float]
+    xAxisCorrection: Optional[float]
+    tiltAngleOffset: Optional[float]
+    zShift: Optional[float]
+
+    class Config:
+        orm_mode = True
+
+
+class MotionCorrection(BaseModel):
+    motionCorrectionId: int
+    dataCollectionId: int
+    autoProcProgramId: Optional[int]
+    imageNumber: Optional[int] = Field(
+        ..., title="Movie number, sequential in time 1-n"
+    )
+    firstFrame: Optional[int] = Field(..., title="First frame of movie used")
+    lastFrame: Optional[int] = Field(..., title="Last frame of movie used")
+    dosePerFrame: Optional[float] = Field(..., title="Dose per frame", unit="e-/A^2")
+    doseWeight: Optional[float] = Field(..., title="Dose weight")
+    totalMotion: Optional[float] = Field(..., title="Total motion", unit="A")
+    averageMotionPerFrame: Optional[float] = Field(
+        ..., title="Average motion per frame", unit="A"
+    )
+    driftPlotFullPath: Optional[str] = Field(
+        ..., max_length=255, title="Path to drift plot"
+    )
+    micrographFullPath: Optional[str] = Field(
+        ..., max_length=255, title="Path to micrograph"
+    )
+    micrographSnapshotFullPath: Optional[str] = Field(
+        ..., max_length=255, title="Path to micrograph"
+    )
+    patchesUsedX: Optional[int] = Field(..., title="Patches used in x")
+    patchesUsedY: Optional[int] = Field(..., title="Patches used in y")
+    fftFullPath: Optional[str] = Field(
+        ...,
+        max_length=255,
+        title="Path to raw micrograph FFT",
+    )
+    fftCorrectedFullPath: Optional[str] = Field(
+        ...,
+        max_length=255,
+        title="Path to drift corrected micrograph FFT",
+    )
+    comments: Optional[str] = Field(..., max_length=255)
+
+    class Config:
+        orm_mode = True
+
+
+class CTF(BaseModel):
+    ctfId: int
+    boxSizeX: Optional[float] = Field(..., title="Box size in x", unit="pixels")
+    boxSizeY: Optional[float] = Field(..., title="Box size in y", unit="pixels")
+    minResolution: Optional[float] = Field(
+        ..., title="Minimum resolution for CTF", unit="A"
+    )
+    maxResolution: Optional[float] = Field(..., unit="A")
+    minDefocus: Optional[float] = Field(..., unit="A")
+    maxDefocus: Optional[float] = Field(..., unit="A")
+    defocusStepSize: Optional[float] = Field(..., unit="A")
+    astigmatism: Optional[float] = Field(..., unit="A")
+    astigmatismAngle: Optional[float] = Field(..., unit="deg?")
+    estimatedResolution: Optional[float] = Field(..., unit="A")
+    estimatedDefocus: Optional[float] = Field(..., unit="A")
+    amplitudeContrast: Optional[float] = Field(..., unit="%?")
+    ccValue: Optional[float] = Field(..., title="Correlation value")
+    fftTheoreticalFullPath: Optional[str] = Field(
+        ..., max_length=255, title="Full path to the jpg image of the simulated FFT"
+    )
+    comments: Optional[str] = Field(..., max_length=255)
+
+    class Config:
+        orm_mode = True
+
+
+class Movie(BaseModel):
+    movieId: int
+    movieNumber: int
+    movieFullPath: Optional[str] = Field(..., max_length=255)
+    createdTimeStamp: datetime
+    positionX: Optional[float]
+    positionY: Optional[float]
+    nominalDefocus: Optional[float] = Field(..., title="Nominal defocus", unit="A")
+    angle: Optional[float] = Field(
+        ..., unit="degrees relative to perpendicular to beam"
+    )
+    fluence: Optional[float] = Field(
+        ...,
+        title="accumulated electron fluence from start to end of acquisition of this movie",
+    )
+    numberOfFrames: Optional[int] = Field(
+        ...,
+        title="number of frames per movie",
+    )
+
+    class Config:
+        orm_mode = True
+
+
+class FullMovie(BaseModel):
+    CTF: CTF
+    Movie: Movie
+    MotionCorrection: MotionCorrection

--- a/pyispyb/filters.py
+++ b/pyispyb/filters.py
@@ -30,6 +30,12 @@ def proposalId(
     return proposalId
 
 
+def movieId(
+    movieId: Optional[int] = Query(None, description="Movie id to filter by")
+) -> Optional[int]:
+    return movieId
+
+
 def beamLineName(
     beamLineName: Optional[str] = Query(None, description="Beamline name to filter by")
 ) -> Optional[str]:

--- a/tests/core/api/data/em.py
+++ b/tests/core/api/data/em.py
@@ -1,0 +1,44 @@
+from tests.core.api.utils.apitest import ApiTestElem, ApiTestExpected, ApiTestInput
+
+
+test_em_list = [
+    ApiTestElem(
+        name="List movies",
+        input=ApiTestInput(
+            permissions=[],
+            login="abcd",
+            route="/em/movies",
+        ),
+        expected=ApiTestExpected(
+            code=200,
+        ),
+    ),
+]
+
+test_em_fft = [
+    ApiTestElem(
+        name="Get FFT thumbnail",
+        input=ApiTestInput(
+            permissions=[],
+            login="abcd",
+            route="/em/movie/1/thumbnail/fft",
+        ),
+        expected=ApiTestExpected(
+            code=404,
+        ),
+    ),
+]
+
+test_em_micrograph = [
+    ApiTestElem(
+        name="Get micrograph snapshot",
+        input=ApiTestInput(
+            permissions=[],
+            login="abcd",
+            route="/em/movie/1/snapshot/micrograph",
+        ),
+        expected=ApiTestExpected(
+            code=404,
+        ),
+    ),
+]

--- a/tests/core/api/test_em.py
+++ b/tests/core/api/test_em.py
@@ -1,0 +1,22 @@
+import pytest
+
+from starlette.types import ASGIApp
+
+from tests.conftest import AuthClient
+from tests.core.api.utils.apitest import get_elem_name, run_test, ApiTestElem
+from tests.core.api.data.em import test_em_fft, test_em_list, test_em_micrograph
+
+
+@pytest.mark.parametrize("test_elem", test_em_list, ids=get_elem_name)
+def test_em_list(auth_client: AuthClient, test_elem: ApiTestElem, app: ASGIApp):
+    run_test(auth_client, test_elem, app)
+
+
+@pytest.mark.parametrize("test_elem", test_em_fft, ids=get_elem_name)
+def test_em_fft(auth_client: AuthClient, test_elem: ApiTestElem, app: ASGIApp):
+    run_test(auth_client, test_elem, app)
+
+
+@pytest.mark.parametrize("test_elem", test_em_micrograph, ids=get_elem_name)
+def test_em_micrograph(auth_client: AuthClient, test_elem: ApiTestElem, app: ASGIApp):
+    run_test(auth_client, test_elem, app)


### PR DESCRIPTION
Adds EM endpoints for:

- FFT thumbnails
- Micrograph snapshots
- Movie data

One detail in movie data is that it also includes motion correction and CTF data, since these operate more often than not as a 1:1 relationship and whenever displaying movie data, it's common that motion correction and CTF information is requested as well.