### PR TITLE
fix permission_required return code

### DIFF
--- a/pyispyb/app/extensions/auth/bearer.py
+++ b/pyispyb/app/extensions/auth/bearer.py
@@ -98,6 +98,6 @@ def permission_required(operator, permissions):
                 )
             )
             msg += " to execute method."
-            raise HTTPException(status_code=401, detail=msg)
+            raise HTTPException(status_code=403, detail=msg)
 
     return res

--- a/tests/core/api/data/legacy/sessions.py
+++ b/tests/core/api/data/legacy/sessions.py
@@ -767,7 +767,7 @@ test_data_session_proposal_list = [
             route="/legacy/sessions/proposal/MX1",
         ),
         expected=ApiTestExpected(
-            code=401,
+            code=403,
             res={
                 "detail": "User pasteur (permissions assigned: []) has no appropriate permission (any: ['own_sessions', 'all_sessions'])  to execute method."
             },


### PR DESCRIPTION
`permission_required` decorator used by legacy routes was returning `401` instead of `403` when user has no appropriate permission.